### PR TITLE
Added dynamic test port

### DIFF
--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -681,7 +681,12 @@ class PlatformBuild
 		/// RUN THE APP IN A THREAD
 		neko.vm.Thread.create(runApp);
 
-		// TODO: Find a better/central place for the hardcoded fallback port 8181 ?
+		/**
+		* TODO: Find a better/central place for the hardcoded fallback port 8181
+		*       which is intended fall back on if the duell-tool's configuration
+		*       does not provide the TEST_PORT property (backward-compatibility).
+		*       Remove eventually...
+		**/
 		var testPort:Int = untyped Configuration.getData().TEST_PORT == null ?
 			8181 : Configuration.getData().TEST_PORT;
 

--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -681,9 +681,12 @@ class PlatformBuild
 		/// RUN THE APP IN A THREAD
 		neko.vm.Thread.create(runApp);
 
-		trace('!!!!! Set DUELLBUILDIOS TEST_PORT to: ' + Configuration.getData().TEST_PORT + ' !!!!!');
+		// TODO: Find a better/central place for the hardcoded fallback port 8181 ?
+		var testPort:Int = untyped Configuration.getData().TEST_PORT == null ?
+			8181 : Configuration.getData().TEST_PORT;
+
 		/// RUN THE LISTENER
-		TestHelper.runListenerServer(300, Configuration.getData().TEST_PORT, fullTestResultPath);
+		TestHelper.runListenerServer(300, testPort, fullTestResultPath);
 	}
 
 	public function clean()

--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -681,8 +681,9 @@ class PlatformBuild
 		/// RUN THE APP IN A THREAD
 		neko.vm.Thread.create(runApp);
 
+		trace('!!! iOS test port set to: ' + Configuration.getData().TEST_PORT + ' !!!');
 		/// RUN THE LISTENER
-		TestHelper.runListenerServer(300, 8181, fullTestResultPath);
+		TestHelper.runListenerServer(300, Configuration.getData().TEST_PORT, fullTestResultPath);
 	}
 
 	public function clean()

--- a/duell/build/plugin/platform/PlatformBuild.hx
+++ b/duell/build/plugin/platform/PlatformBuild.hx
@@ -681,7 +681,7 @@ class PlatformBuild
 		/// RUN THE APP IN A THREAD
 		neko.vm.Thread.create(runApp);
 
-		trace('!!! iOS test port set to: ' + Configuration.getData().TEST_PORT + ' !!!');
+		trace('!!!!! Set DUELLBUILDIOS TEST_PORT to: ' + Configuration.getData().TEST_PORT + ' !!!!!');
 		/// RUN THE LISTENER
 		TestHelper.runListenerServer(300, Configuration.getData().TEST_PORT, fullTestResultPath);
 	}


### PR DESCRIPTION
Hello SGF team,

in terms of making the earlier pull request for the duell-tool work I'd like you the review and add this branch to the duellbuildios library by chance. It would help to have two clients running on one virtual machine, both using different ports to not interfere each other.

Thanks,
Fabian
