### PR TITLE
Ns app transport security fix

### DIFF
--- a/duell/build/plugin/platform/PlatformConfiguration.hx
+++ b/duell/build/plugin/platform/PlatformConfiguration.hx
@@ -43,6 +43,13 @@ typedef PlistEntry =
 	VALUE : String
 };
 
+typedef ExceptionDomain = 
+{
+	URL : String,
+	PROPERTIES : String
+}
+
+
 typedef KeyValueArray = Array<{NAME : String, VALUE : String}>;
 
 typedef PlatformConfigurationData = {
@@ -69,6 +76,7 @@ typedef PlatformConfigurationData = {
 	ENTITLEMENTS_PATH : String,
 	INFOPLIST_SECTIONS: Array<String>,
 	INFOPLIST_ENTRIES: Array<PlistEntry>,
+	EXCEPTION_DOMAINS: Array<ExceptionDomain>,
 
 	/// derived from the data above
 	FRAMEWORK_SEARCH_PATHS : Array<String>,
@@ -136,6 +144,7 @@ class PlatformConfiguration
 			ENTITLEMENTS_PATH : "",
 			INFOPLIST_SECTIONS: [],
 			INFOPLIST_ENTRIES: [],
+			EXCEPTION_DOMAINS: [],
 
 			FRAMEWORK_SEARCH_PATHS : [],
 			ADDL_PBX_BUILD_FILE : [],

--- a/duell/build/plugin/platform/PlatformConfiguration.hx
+++ b/duell/build/plugin/platform/PlatformConfiguration.hx
@@ -46,9 +46,8 @@ typedef PlistEntry =
 typedef ExceptionDomain = 
 {
 	URL : String,
-	PROPERTIES : String
+	PROPERTIES : KeyValueArray
 }
-
 
 typedef KeyValueArray = Array<{NAME : String, VALUE : String}>;
 

--- a/duell/build/plugin/platform/PlatformXMLParser.hx
+++ b/duell/build/plugin/platform/PlatformXMLParser.hx
@@ -127,8 +127,8 @@ class PlatformXMLParser
 				case 'infoplist-entry':
 					parseInfoPlistEntryElement(element);
 
-				case 'exceptiondomains':
-					 parseExceptionDomains(element);
+				case 'exceptiondomain':
+					 parseExceptionDomain(element);
 
 			}
 		}
@@ -367,28 +367,26 @@ class PlatformXMLParser
 		}
 	}
 
-	private static function parseExceptionDomains(element : Fast)
+	private static function parseExceptionDomain(element : Fast)
 	{
-		var url : String = "";
-		var prop : String = "";
+		var url : String = element.att.url;
+		var key : String = "";
+		var value : String = "";
+		var properties : KeyValueArray = [];
 
-		for (d in element.elements)
+		for (property in element.elements)
 		{
-			switch(d.name)
-			{
-				case "key":
-					 url = d.innerData;
+			key = property.att.key;
+			value = property.att.value;
 
-				case "dict":
-					 prop = d.innerHTML;
-					 var exception : ExceptionDomain = {
-					 	URL : url,
-					 	PROPERTIES : prop
-					 }
-
-					 PlatformConfiguration.getData().EXCEPTION_DOMAINS.push(exception);
-			}
+			properties.push({NAME : key, VALUE : value});
 		}
+
+		var exception : ExceptionDomain = {
+			URL : url,
+			PROPERTIES : properties
+		}
+		PlatformConfiguration.getData().EXCEPTION_DOMAINS.push(exception);
 	}
 
 	/// HELPERS

--- a/duell/build/plugin/platform/PlatformXMLParser.hx
+++ b/duell/build/plugin/platform/PlatformXMLParser.hx
@@ -126,6 +126,10 @@ class PlatformXMLParser
 
 				case 'infoplist-entry':
 					parseInfoPlistEntryElement(element);
+
+				case 'exceptiondomains':
+					 parseExceptionDomains(element);
+
 			}
 		}
 	}
@@ -360,6 +364,30 @@ class PlatformXMLParser
 			};
 
 			PlatformConfiguration.getData().INFOPLIST_ENTRIES.push(entry);
+		}
+	}
+
+	private static function parseExceptionDomains(element : Fast)
+	{
+		var url : String = "";
+		var prop : String = "";
+
+		for (d in element.elements)
+		{
+			switch(d.name)
+			{
+				case "key":
+					 url = d.innerData;
+
+				case "dict":
+					 prop = d.innerHTML;
+					 var exception : ExceptionDomain = {
+					 	URL : url,
+					 	PROPERTIES : prop
+					 }
+
+					 PlatformConfiguration.getData().EXCEPTION_DOMAINS.push(exception);
+			}
 		}
 	}
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -72,8 +72,8 @@
             Use this to add custom parameters to the info.plist file of the project. E.g.: &lt;infoplist-section&gt;&lt;key&gt;NSAppTransportSecurity&lt;/key&gt;&lt;dict&gt;&lt;key&gt;NSAllowsArbitraryLoads&lt;/key&gt;&lt;true/&gt;&lt;/dict&gt;&lt;/infoplist-section&gt;
 		</elem>
 
-		<elem name="exceptiondomains">
-			You can opt-out of Apple's transport security (ATS) for certain URLs in your Info.plist by using NSExceptionDomains. Within the NSExceptionDomains dictionary you can explicitly define URLs that you need exceptions for with ATS. E.g.:&lt;exceptiondomains&gt;&lt;key&gt;socialstage.gameduell.de&lt;/key&gt;&lt;dict&gt;&lt;key&gt;NSIncludesSubdomains&lt;/key&gt;&lt;true/&gt;&lt;key&gt;NSThirdPartyExceptionRequiresForwardSecrecy&lt;/key&gt;&lt;false/&gt;&lt;/dict&gt;&lt;/exceptiondomains&gt;
+		<elem name="exceptiondomain">
+			You can opt-out of Apple's transport security (ATS) for certain URLs in your Info.plist by using this node. To do so, create nodes of the following format:&lt;exceptiondomain url='de.your.special.domain'&gt;&lt;property key='NSIncludesSubdomains' value='true' /&gt;&lt;/exceptiondomain&gt; You can add as much properties as you want but you need at least one when defining a exceptiondomain.
 		</elem>
 
 		<elem name="infoplist-entry">

--- a/plugin.xml
+++ b/plugin.xml
@@ -72,6 +72,10 @@
             Use this to add custom parameters to the info.plist file of the project. E.g.: &lt;infoplist-section&gt;&lt;key&gt;NSAppTransportSecurity&lt;/key&gt;&lt;dict&gt;&lt;key&gt;NSAllowsArbitraryLoads&lt;/key&gt;&lt;true/&gt;&lt;/dict&gt;&lt;/infoplist-section&gt;
 		</elem>
 
+		<elem name="exceptiondomains">
+			You can opt-out of Apple's transport security (ATS) for certain URLs in your Info.plist by using NSExceptionDomains. Within the NSExceptionDomains dictionary you can explicitly define URLs that you need exceptions for with ATS. E.g.:&lt;exceptiondomains&gt;&lt;key&gt;socialstage.gameduell.de&lt;/key&gt;&lt;dict&gt;&lt;key&gt;NSIncludesSubdomains&lt;/key&gt;&lt;true/&gt;&lt;key&gt;NSThirdPartyExceptionRequiresForwardSecrecy&lt;/key&gt;&lt;false/&gt;&lt;/dict&gt;&lt;/exceptiondomains&gt;
+		</elem>
+
 		<elem name="infoplist-entry">
 			Use this to add entries to the info.plist file of the project. Possible values for type are "string", "number", "bool" and "dynamic". "dynamic" will take the value specified literally as is. E.g.: &lt;infoplist-entry key="FacebookAppID" type="string" value="12345678" /&gt;.
 		</elem>

--- a/schema.xsd
+++ b/schema.xsd
@@ -28,6 +28,7 @@
             <xs:element name="required-capability" type="d:NameValueNameRequired"/>
             <xs:element name="entitlements" type="d:Path" />
             <xs:element name="infoplist-section" type="d:IgnoreContents"/>
+            <xs:element name="exceptiondomains" type="d:IgnoreContents"/>
             <xs:element name="infoplist-entry" type="d:PlistEntry"/>
         </xs:choice>
     </xs:complexType>

--- a/schema.xsd
+++ b/schema.xsd
@@ -28,7 +28,7 @@
             <xs:element name="required-capability" type="d:NameValueNameRequired"/>
             <xs:element name="entitlements" type="d:Path" />
             <xs:element name="infoplist-section" type="d:IgnoreContents"/>
-            <xs:element name="exceptiondomains" type="d:IgnoreContents"/>
+            <xs:element name="exceptiondomain" type="d:ExceptionDomain"/>
             <xs:element name="infoplist-entry" type="d:PlistEntry"/>
         </xs:choice>
     </xs:complexType>
@@ -78,6 +78,24 @@
                 <xs:attribute name="identity" type="xs:string" use="optional"/>
             </xs:extension>
         </xs:complexContent>
+    </xs:complexType>
+
+    <xs:element name="ExceptionDomain" >
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="property" type="propertyType" minOccurs="1" maxOccurs="10" />
+            </xs:sequence>
+            <xs:attribute name="url" type="xs:string"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="propertyType">
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="key" type="xs:string" use="required" />
+                <xs:attribute name="value" type="xs:string" use="required" />
+            </xs:extension>
+        </xs:simpleContent>
     </xs:complexType>
 
 </xs:schema>

--- a/schema.xsd
+++ b/schema.xsd
@@ -80,16 +80,14 @@
         </xs:complexContent>
     </xs:complexType>
 
-    <xs:element name="ExceptionDomain" >
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="property" type="propertyType" minOccurs="1" maxOccurs="10" />
-            </xs:sequence>
-            <xs:attribute name="url" type="xs:string"/>
-        </xs:complexType>
-    </xs:element>
+    <xs:complexType name="ExceptionDomain">
+        <xs:sequence>
+            <xs:element name="property" type="d:PropertyType" maxOccurs="unbounded" />
+        </xs:sequence>
+        <xs:attribute name="url" type="xs:string" use="required" />
+    </xs:complexType>
 
-    <xs:complexType name="propertyType">
+    <xs:complexType name="PropertyType">
         <xs:simpleContent>
             <xs:extension base="xs:string">
                 <xs:attribute name="key" type="xs:string" use="required" />

--- a/template/ios/PROJ/PROJ-Info.plist
+++ b/template/ios/PROJ/PROJ-Info.plist
@@ -113,7 +113,12 @@
         <dict>
         	::foreach PLATFORM.EXCEPTION_DOMAINS::
             <key>::URL::</key>
-            <dict>::PROPERTIES::</dict>
+            <dict>
+            	::foreach PROPERTIES::
+            	<key>::NAME::</key>
+            	::if (VALUE == "true")::<true/>::else::<false/>::end::
+            	::end::
+            </dict>
         	::end::
         </dict>
     </dict>

--- a/template/ios/PROJ/PROJ-Info.plist
+++ b/template/ios/PROJ/PROJ-Info.plist
@@ -105,5 +105,18 @@
      		::__current__::
 		::end::
 	::end::
+
+	::if (PLATFORM.EXCEPTION_DOMAINS.length > 0)::
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSExceptionDomains</key>
+        <dict>
+        	::foreach PLATFORM.EXCEPTION_DOMAINS::
+            <key>::URL::</key>
+            <dict>::PROPERTIES::</dict>
+        	::end::
+        </dict>
+    </dict>
+    ::end::
 </dict>
 </plist>


### PR DESCRIPTION
NSExceptionDomains of different libraries were overridden by others, so only the last parsed one was available in the plist. This branch is fixing this issue by a new node 'exceptiondomain' which should be used instead adding these urls to the infoplist-section.
